### PR TITLE
updated to get information from kubernetes API instead of downward API and support one namespace per application.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.11 3.5.2
+    - pyenv global 2.7.11 3.5.2 3.6.0
 dependencies:
   override:
     - pip install tox

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,12 @@ except ImportError:
 
 install_requires = [
     "datadog-logger",
-    "kubernetes-downward-api",
-    "datadog"
+    "datadog",
+    "kubernetes"
 ]
 
 setup(name="ustack-logging",
-      version="0.1.0",
+      version="0.2.0",
       description="Default logging configuration for uStack style Python applications.",
       url="https://github.com/ustudio/ustack-logging",
       packages=["ustack_logging"],

--- a/tests/test_ustack_logging.py
+++ b/tests/test_ustack_logging.py
@@ -1,5 +1,8 @@
+import base64
 import logging
 import unittest
+
+from kubernetes.client import V1Secret, V1Pod, V1ObjectMeta
 
 try:
     from unittest import mock
@@ -10,55 +13,64 @@ from ustack_logging.logging_configuration import configure_logging
 
 
 class TestLogging(unittest.TestCase):
+    @mock.patch("socket.gethostname")
+    @mock.patch("kubernetes.config.load_incluster_config")
+    @mock.patch("kubernetes.client.CoreV1Api")
     @mock.patch("ustack_logging.logging_configuration.log_error_events", autospec=True)
-    @mock.patch("kubernetes_downward_api.parse", autospec=True)
     @mock.patch("datadog.initialize", autospec=True)
     @mock.patch("logging.basicConfig", autospec=True)
     def test_configures_logging_format_and_logs_errors_to_datadog(
-            self, mock_log_config, mock_dd_init, mock_k8s_parse, mock_log_errors):
-        mock_k8s_parse.return_value = {
-            "namespace": "dev",
-            "labels": {
-                "app": "my_app",
-                "role": "app"
-            }
-        }
+            self, mock_log_config, mock_dd_init, mock_log_errors, mock_k8s_api_class,
+            mock_k8s_config, mock_gethostname):
 
-        configure_logging({
-            "DATADOG_API_KEY": "dd-api-key",
-            "DATADOG_APP_KEY": "dd-app-key"
-        })
+        mock_k8s_api = mock_k8s_api_class.return_value
+
+        mock_gethostname.return_value = "podname.domain"
+
+        mock_k8s_api.read_namespaced_secret.return_value = V1Secret(
+            data={
+                "environment": base64.b64encode("dev".encode("utf8")),
+                "datadog-api-key": base64.b64encode("dd-api-key".encode("utf8")),
+                "datadog-app-key": base64.b64encode("dd-app-key".encode("utf8"))
+            })
+        mock_k8s_api.read_namespaced_pod.return_value = V1Pod(
+            metadata=V1ObjectMeta(labels={
+                "role": "my-role"
+            }))
+
+        with mock.patch(
+                "ustack_logging.logging_configuration.open",
+                mock.mock_open(read_data="my-app"),
+                create=True) as mock_open:
+            configure_logging()
 
         mock_log_config.assert_called_once_with(
             format="%(asctime)s %(levelname)s:%(module)s:%(message)s",
             datefmt="%Y-%m-%d %H:%M:%S%z", level=logging.INFO)
 
+        mock_k8s_config.assert_called_once_with()
+
+        mock_k8s_api.read_namespaced_secret.assert_called_once_with(
+            "environment-info", "ustudio-system")
+
         mock_dd_init.assert_called_once_with(api_key="dd-api-key", app_key="dd-app-key")
 
-        mock_k8s_parse.assert_called_once_with(["/etc/podinfo"])
+        mock_open.assert_called_once_with("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+
+        mock_gethostname.assert_called_once_with()
+
+        mock_k8s_api.read_namespaced_pod.assert_called_once_with("podname", "my-app")
+
         mock_log_errors.assert_called_once_with(
-            tags=["environment:dev", "service:my_app", "role:app"])
+            tags=["environment:dev", "service:my-app", "role:my-role"])
 
-    @mock.patch("ustack_logging.logging_configuration.log_error_events", autospec=True)
-    @mock.patch("kubernetes_downward_api.parse", autospec=True)
-    @mock.patch("datadog.initialize", autospec=True)
+    @mock.patch("kubernetes.config.load_incluster_config")
     @mock.patch("logging.basicConfig", autospec=True)
-    def test_ignores_errors_from_datadog_initialization(
-            self, mock_log_config, mock_dd_init, mock_k8s_parse, mock_log_errors):
-        mock_k8s_parse.return_value = {
-            "namespace": "dev",
-            "labels": {
-                "app": "my_app",
-                "role": "app"
-            }
-        }
+    def test_ignores_errors_from_datadog_initialization(self, mock_log_config, mock_k8s_config):
 
-        mock_dd_init.side_effect = RuntimeError
+        mock_k8s_config.side_effect = RuntimeError
 
-        configure_logging({
-            "DATADOG_API_KEY": "dd-api-key",
-            "DATADOG_APP_KEY": "dd-app-key"
-        })
+        configure_logging()
 
         mock_log_config.assert_called_once_with(
             format="%(asctime)s %(levelname)s:%(module)s:%(message)s",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35
+envlist = py27, py35, py36
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
@ustudio/dev  please review

As we discussed, we need to update the library to support one namespace per application and one cluster per namespace.  Because there is no way to get cluster-wide information from the Downward API we need to access it via the Kubernetes API.  

Since we were already using the Kubernetes API we removed the dependence on the Downward API and now access all information via the Kubernetes API.  This has the added benefit of requiring no special configuration of the pod to use the library.  

We decided to store the `environment-info` secret in the `ustudio-system` namespace where we were already running the SumoLogic and DataDog integrations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/ustack-logging/3)
<!-- Reviewable:end -->
