### PR TITLE
Removed use of datadog-app-key secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,11 @@ pip install ustack-logging
 ## Usage ##
 
 ```python
-import os
 from ustack_logging.logging_configuration import configure_logging
 
 
 def main():
-    configure_logging(os.environ)
+    configure_logging()
 
     # Run your application
 
@@ -32,11 +31,9 @@ applications log and report errors when running inside Kubernetes. It
 takes no configuration because its intent is to enforce a
 configuration.
 
-However, it is built on separate libraries that *are* configurable:
-[datadog-logger](https://github.com/ustudio/datadog-logger) and
-[kubernetes-downward-api](https://github.com/ustudio/kubernetes-downward-api). If
-you need a different configuration, it should be trivial to implement
-it using those libraries.
+However, it is built on [datadog-logger](https://github.com/ustudio/datadog-logger),
+which is configurable. If you need a different configuration, it
+should be trivial to implement it using that library directly.
 
 ## Configuration ##
 
@@ -46,18 +43,17 @@ It sets up the logging library to log the time, log level, module name
 and log message for every message, and it sets the current log level
 to `INFO`.
 
-It connects to Datadog using the environment variables
-`DATADOG_API_KEY` and `DATADOG_APP_KEY`, and parses the Kubernetes
-namespace and labels out of a Kubernetes Downward API VolumeMount at
-`/etc/podinfo`.
+In order to function, it uses a secret named `environment-info` in the
+`ustudio-system` namespace. The secret must contain the keys
+`environment` and `datadog-api-key`, and the pod must contain a label
+named `role`.
 
-If the environment variables are not set (or are incorrect) or the
-Downward API VolumeMount isn't available it logs a warning and does
-not error.
+If any information is missing or any connections fail it logs a
+warning and does not error.
 
 It configures the `datadog-logger` library to send `ERROR` and above
 log messages to Datadog as events, with the following tag mapping:
 
-* K8s Namespace -> Datadog tag `environment`
-* K8s Pod Label `app` -> Datadog tag `service`
+* `environment-info.environment` -> Datadog tag `environment`
+* K8s Pod Namespace -> Datadog tag `service`
 * K8s Pod Label `role` -> Datadog tag `role`

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ install_requires = [
 ]
 
 setup(name="ustack-logging",
-      version="0.2.0",
+      version="0.2.1",
       description="Default logging configuration for uStack style Python applications.",
       url="https://github.com/ustudio/ustack-logging",
       packages=["ustack_logging"],

--- a/tests/test_ustack_logging.py
+++ b/tests/test_ustack_logging.py
@@ -31,7 +31,6 @@ class TestLogging(unittest.TestCase):
             data={
                 "environment": base64.b64encode("dev".encode("utf8")),
                 "datadog-api-key": base64.b64encode("dd-api-key".encode("utf8")),
-                "datadog-app-key": base64.b64encode("dd-app-key".encode("utf8"))
             })
         mock_k8s_api.read_namespaced_pod.return_value = V1Pod(
             metadata=V1ObjectMeta(labels={
@@ -53,7 +52,7 @@ class TestLogging(unittest.TestCase):
         mock_k8s_api.read_namespaced_secret.assert_called_once_with(
             "environment-info", "ustudio-system")
 
-        mock_dd_init.assert_called_once_with(api_key="dd-api-key", app_key="dd-app-key")
+        mock_dd_init.assert_called_once_with(api_key="dd-api-key")
 
         mock_open.assert_called_once_with("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 

--- a/ustack_logging/logging_configuration.py
+++ b/ustack_logging/logging_configuration.py
@@ -18,8 +18,7 @@ def configure_logging():
         environment_info = core_api.read_namespaced_secret("environment-info", "ustudio-system")
 
         datadog.initialize(
-            api_key=base64.b64decode(environment_info.data["datadog-api-key"]).decode("utf8"),
-            app_key=base64.b64decode(environment_info.data["datadog-app-key"]).decode("utf8"))
+            api_key=base64.b64decode(environment_info.data["datadog-api-key"]).decode("utf8"))
 
         with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
             namespace = f.read()


### PR DESCRIPTION
The DataDog application key is not required in order to create events, so we removed the usage of it.

Also, we updated the README to reflect new configuration requirements.

@ustudio/dev Please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ustudio/ustack-logging/4)
<!-- Reviewable:end -->
